### PR TITLE
Rename importClass to importConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Documentation
     * [Lumen](#lumen)
     * [Without Framework](#without-framework)
 * [How to use](#how-to-use)
-    * [ImportClass](#importclass)
+    * [ImportConfiguration](#importconfiguration)
         * [BeforeImport](#beforeimport)
         * [ChunkImport](#chunkimport)
     * [Import](#import)
@@ -94,7 +94,7 @@ $importerFactory->addReader(new XlsxReader());
 
 $importer = $importerFactory->getImporter('csv');
 $importer->fromString('some,csv,string')
-    ->useImportClass(new YourImportClass())
+    ->useImportConfiguration(new YourImportConfiguration())
     ->import();
 ```
 
@@ -102,17 +102,15 @@ $importer->fromString('some,csv,string')
 
 ## How to use
 
-### ImportClass
+### ImportConfiguration
 
-Import class defines how should the data be mapped and saves the data. They have to implement
-`KunicMarko\Importer\Import` interface.
+ImportConfiguration defines how should the data be mapped and saves the data.
+They have to implement `KunicMarko\Importer\ImportConfiguration` interface.
 
 ```php
-namespace KunicMarko\Importer\Tests\Fixtures;
+use KunicMarko\Importer\ImportConfiguration;
 
-use KunicMarko\Importer\Import;
-
-class ImportClass implements Import
+class ImportUserConfiguration implements ImportConfiguration
 {
     public function map(array $item, array $additionalData)
     {
@@ -133,16 +131,14 @@ class ImportClass implements Import
 
 #### BeforeImport
 
-BeforeImport allows your ImportClass to do something with data before the mapping starts.
+BeforeImport allows your ImportConfiguration to do something with data before the mapping starts.
 
 ```php
-namespace KunicMarko\Importer\Tests\Fixtures;
-
-use KunicMarko\Importer\Import;
+use KunicMarko\Importer\ImportConfiguration;
 use KunicMarko\Importer\BeforeImport;
 use Iterator;
 
-class ImportClass implements Import, BeforeImport
+class ImportSomethingConfiguration implements ImportConfiguration, BeforeImport
 {
     public function before(Iterator $items, array $additionalData): Iterator
     {
@@ -156,16 +152,15 @@ class ImportClass implements Import, BeforeImport
 
 #### ChunkImport
 
-ChunkImport allows your class to define a number of items that the save method will receive,
-instead of receiving all at once.
+ChunkImport allows your configuration to define a number of items that the save method will
+receive, instead of receiving all at once.
 
 ```php
-namespace KunicMarko\Importer\Tests\Fixtures;
 
-use KunicMarko\Importer\Import;
+use KunicMarko\Importer\ImportConfiguration;
 use KunicMarko\Importer\ChunkImport;
 
-class ImportClass implements Import, ChunkImport
+class ImportChunkSomethingConfiguration implements ImportConfiguration, ChunkImport
 {
     public function chunkSize(): int
     {
@@ -181,8 +176,8 @@ class ImportClass implements Import, ChunkImport
 
 ### Import
 
-After you have defined your import class, you can import from a file or from a string. You HAVE to
-provide one of those 2 options and your import class.
+After you have defined your import configuration, you can import from a file or from a string.
+You HAVE to provide one of those 2 options and your import configuration.
 
 #### Import From File
 
@@ -203,7 +198,7 @@ class UserImport
         $importer = $importerFactory->getImporter('csv');
 
         $importer->fromFile('path/to/file.csv')
-            ->useImportClass(new YourImportClass())
+            ->useImportConfiguration(new YourImportConfiguration())
             ->import();
     }
 }
@@ -228,7 +223,7 @@ class UserImport
         $importer = $importerFactory->getImporter('csv');
 
         $importer->fromString('some,csv,string')
-            ->useImportClass(new YourImportClass())
+            ->useImportConfiguration(new YourImportConfiguration())
             ->import();
     }
 }
@@ -238,7 +233,7 @@ class UserImport
 
 ### Pass Additional Data
 
-Sometimes you may want to pass additional data to your import class.
+Sometimes you may want to pass additional data to your import configuration.
 
 ```php
 use KunicMarko\Importer\ImporterFactory;
@@ -257,7 +252,7 @@ class UserImport
         $importer = $importerFactory->getImporter('csv');
 
         $importer->fromString('some,csv,string')
-            ->useIamportClass(new YourImportClass())
+            ->useImportConfiguration(new YourImportConfiguration())
             ->withAdditionalData(['user' => 'kunicmarko20'])
             ->import();
     }

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,9 +3,16 @@
 UPGRADE FROM 0.1.0 to 0.2.0
 ===========================
 
+`KunicMarko\Importer\Import` has been renamed to `KunicMarko\Importer\ImportConfiguration`.
+
+`Importer::useImportClass` has been renamed to `Importer::useImportConfiguration`.
+
+`Importer::import` now throws exception if ImportConfiguration is not provided.
+
 `BeforeImport::before` now accepts second parameter `$additionalData`.
-`Import::map` now accepts second parameter `$additionalData`.
-`Import::save` now accepts second parameter `$additionalData`.
+`ImportConfiguration::map` now accepts second parameter `$additionalData`.
+`ImportConfiguration::save` now accepts second parameter `$additionalData`.
 
 New method `Importer::withAdditionalData` that allows you to pass any additional data
 you need to get into your import class.
+

--- a/src/ImportConfiguration.php
+++ b/src/ImportConfiguration.php
@@ -5,7 +5,7 @@ namespace KunicMarko\Importer;
 /**
  * @author Marko Kunic <kunicmarko20@gmail.com>
  */
-interface Import
+interface ImportConfiguration
 {
     public function map(array $item, array $additionalData);
     public function save(array $items, array $additionalData): void;

--- a/tests/Fixtures/ChunkImportConfiguration.php
+++ b/tests/Fixtures/ChunkImportConfiguration.php
@@ -4,13 +4,15 @@ namespace KunicMarko\Importer\Tests\Fixtures;
 
 use Iterator;
 use KunicMarko\Importer\BeforeImport;
-use KunicMarko\Importer\Import;
+use KunicMarko\Importer\ChunkImport;
+use KunicMarko\Importer\ImportConfiguration;
 use PHPUnit\Framework\TestCase;
+use function count;
 
 /**
  * @author Marko Kunic <kunicmarko20@gmail.com>
  */
-class ImportClass extends TestCase implements Import, BeforeImport
+class ChunkImportConfiguration extends TestCase implements ImportConfiguration, ChunkImport, BeforeImport
 {
     public function before(Iterator $items, array $additionalData): Iterator
     {
@@ -19,20 +21,18 @@ class ImportClass extends TestCase implements Import, BeforeImport
         return $items;
     }
 
+    public function chunkSize(): int
+    {
+        return 50;
+    }
+
     public function map(array $item, array $additionalData)
     {
-        if ($additionalData) {
-            $this->assertSame('testing', reset($additionalData));
-        }
-
         return $item;
     }
 
     public function save(array $items, array $additionalData): void
     {
-        $this->assertCount(999, $items);
-
-        $first = reset($items);
-        $this->assertSame(2, (int) reset($first));
+        $this->assertLessThanOrEqual(50, count($items));
     }
 }

--- a/tests/Fixtures/ImportConfiguration.php
+++ b/tests/Fixtures/ImportConfiguration.php
@@ -4,15 +4,13 @@ namespace KunicMarko\Importer\Tests\Fixtures;
 
 use Iterator;
 use KunicMarko\Importer\BeforeImport;
-use KunicMarko\Importer\ChunkImport;
-use KunicMarko\Importer\Import;
+use KunicMarko\Importer\ImportConfiguration as ImportConfigurationInterface;
 use PHPUnit\Framework\TestCase;
-use function count;
 
 /**
  * @author Marko Kunic <kunicmarko20@gmail.com>
  */
-class ChunkImportClass extends TestCase implements Import, ChunkImport, BeforeImport
+class ImportConfiguration extends TestCase implements ImportConfigurationInterface, BeforeImport
 {
     public function before(Iterator $items, array $additionalData): Iterator
     {
@@ -21,18 +19,20 @@ class ChunkImportClass extends TestCase implements Import, ChunkImport, BeforeIm
         return $items;
     }
 
-    public function chunkSize(): int
-    {
-        return 50;
-    }
-
     public function map(array $item, array $additionalData)
     {
+        if ($additionalData) {
+            $this->assertSame('testing', reset($additionalData));
+        }
+
         return $item;
     }
 
     public function save(array $items, array $additionalData): void
     {
-        $this->assertLessThanOrEqual(50, count($items));
+        $this->assertCount(999, $items);
+
+        $first = reset($items);
+        $this->assertSame(2, (int) reset($first));
     }
 }

--- a/tests/Fixtures/ImportNestedJsonConfiguration.php
+++ b/tests/Fixtures/ImportNestedJsonConfiguration.php
@@ -8,7 +8,7 @@ use ArrayIterator;
 /**
  * @author Marko Kunic <kunicmarko20@gmail.com>
  */
-class ImportNestedJsonClass extends ImportClass
+class ImportNestedJsonConfiguration extends ImportConfiguration
 {
     /**
      * @param ArrayIterator|Iterator $items

--- a/tests/ImporterTest.php
+++ b/tests/ImporterTest.php
@@ -2,15 +2,15 @@
 
 namespace KunicMarko\Importer\Tests;
 
-use KunicMarko\Importer\Import;
+use KunicMarko\Importer\ImportConfiguration as ImportConfigurationInterface;
 use KunicMarko\Importer\ImporterFactory;
 use KunicMarko\Importer\Reader\CsvReader;
 use KunicMarko\Importer\Reader\XlsxReader;
 use KunicMarko\Importer\Reader\JsonReader;
 use KunicMarko\Importer\Reader\XmlReader;
-use KunicMarko\Importer\Tests\Fixtures\ChunkImportClass;
-use KunicMarko\Importer\Tests\Fixtures\ImportClass;
-use KunicMarko\Importer\Tests\Fixtures\ImportNestedJsonClass;
+use KunicMarko\Importer\Tests\Fixtures\ChunkImportConfiguration;
+use KunicMarko\Importer\Tests\Fixtures\ImportConfiguration;
+use KunicMarko\Importer\Tests\Fixtures\ImportNestedJsonConfiguration;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -24,9 +24,9 @@ class ImporterTest extends TestCase
     private $importerFactory;
 
     /**
-     * @var Import
+     * @var ImportConfigurationInterface
      */
-    private $importClass;
+    private $importConfiguration;
 
     public function setUp()
     {
@@ -36,7 +36,7 @@ class ImporterTest extends TestCase
         $this->importerFactory->addReader(new XlsxReader());
         $this->importerFactory->addReader(new XmlReader());
 
-        $this->importClass = new ImportClass();
+        $this->importConfiguration = new ImportConfiguration();
     }
 
     public function testCsvImportFromFile(): void
@@ -44,7 +44,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('csv');
 
         $importer->fromFile(__DIR__ . '/Fixtures/fake.csv')
-            ->useImportClass($this->importClass)
+            ->useImportConfiguration($this->importConfiguration)
             ->import();
     }
 
@@ -53,7 +53,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('csv');
 
         $importer->fromString(file_get_contents(__DIR__ . '/Fixtures/fake.csv'))
-            ->useImportClass($this->importClass)
+            ->useImportConfiguration($this->importConfiguration)
             ->import();
     }
 
@@ -62,7 +62,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('xml');
 
         $importer->fromFile(__DIR__ . '/Fixtures/fake.xml')
-            ->useImportClass($this->importClass)
+            ->useImportConfiguration($this->importConfiguration)
             ->import();
     }
 
@@ -71,7 +71,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('xml');
 
         $importer->fromString(file_get_contents(__DIR__ . '/Fixtures/fake.xml'))
-            ->useImportClass($this->importClass)
+            ->useImportConfiguration($this->importConfiguration)
             ->import();
     }
 
@@ -80,7 +80,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('json');
 
         $importer->fromFile(__DIR__ . '/Fixtures/fake.json')
-            ->useImportClass($this->importClass)
+            ->useImportConfiguration($this->importConfiguration)
             ->import();
     }
 
@@ -89,7 +89,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('json');
 
         $importer->fromString(file_get_contents(__DIR__ . '/Fixtures/fake.json'))
-            ->useImportClass($this->importClass)
+            ->useImportConfiguration($this->importConfiguration)
             ->import();
     }
 
@@ -98,7 +98,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('json');
 
         $importer->fromFile(__DIR__ . '/Fixtures/fake_nested.json')
-            ->useImportClass(new ImportNestedJsonClass())
+            ->useImportConfiguration(new ImportNestedJsonConfiguration())
             ->import();
     }
 
@@ -107,7 +107,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('json');
 
         $importer->fromString(file_get_contents(__DIR__ . '/Fixtures/fake_nested.json'))
-            ->useImportClass(new ImportNestedJsonClass())
+            ->useImportConfiguration(new ImportNestedJsonConfiguration())
             ->import();
     }
 
@@ -116,7 +116,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('xlsx');
 
         $importer->fromFile(__DIR__ . '/Fixtures/fake.xlsx')
-            ->useImportClass($this->importClass)
+            ->useImportConfiguration($this->importConfiguration)
             ->import();
     }
 
@@ -125,7 +125,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('xlsx');
 
         $importer->fromFile(__DIR__ . '/Fixtures/fake.xlsx')
-            ->useImportClass($this->importClass)
+            ->useImportConfiguration($this->importConfiguration)
             ->withAdditionalData(['test' => 'testing'])
             ->import();
     }
@@ -138,7 +138,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('xlsx');
 
         $importer->fromString('nop')
-            ->useImportClass($this->importClass)
+            ->useImportConfiguration($this->importConfiguration)
             ->import();
     }
 
@@ -147,7 +147,7 @@ class ImporterTest extends TestCase
         $importer = $this->importerFactory->getImporter('csv');
 
         $importer->fromFile(__DIR__ . '/Fixtures/fake.csv')
-            ->useImportClass(new ChunkImportClass())
+            ->useImportConfiguration(new ChunkImportConfiguration())
             ->import();
     }
 
@@ -162,11 +162,23 @@ class ImporterTest extends TestCase
     /**
      * @expectedException \KunicMarko\Importer\Exception\InvalidArgumentException
      */
+    public function testNoImportConfiguration(): void
+    {
+        $importer = $this->importerFactory->getImporter('csv');
+
+        $importer->import();
+    }
+
+    /**
+     * @expectedException \KunicMarko\Importer\Exception\InvalidArgumentException
+     */
     public function testFileNotFound(): void
     {
         $importer = $this->importerFactory->getImporter('csv');
 
-        $importer->fromFile('fake');
+        $importer
+            ->useImportConfiguration(new ChunkImportConfiguration())
+            ->fromFile('fake');
     }
 
     /**
@@ -176,7 +188,9 @@ class ImporterTest extends TestCase
     {
         $importer = $this->importerFactory->getImporter('csv');
 
-        $importer->fromString('');
+        $importer
+            ->useImportConfiguration(new ChunkImportConfiguration())
+            ->fromString('');
     }
 
     /**
@@ -186,7 +200,9 @@ class ImporterTest extends TestCase
     {
         $importer = $this->importerFactory->getImporter('json');
 
-        $importer->import();
+        $importer
+            ->useImportConfiguration(new ChunkImportConfiguration())
+            ->import();
     }
 
     /**
@@ -196,7 +212,9 @@ class ImporterTest extends TestCase
     {
         $importer = $this->importerFactory->getImporter('xlsx');
 
-        $importer->import();
+        $importer
+            ->useImportConfiguration(new ChunkImportConfiguration())
+            ->import();
     }
 
     /**
@@ -206,7 +224,9 @@ class ImporterTest extends TestCase
     {
         $importer = $this->importerFactory->getImporter('csv');
 
-        $importer->import();
+        $importer
+            ->useImportConfiguration(new ChunkImportConfiguration())
+            ->import();
     }
 
     /**
@@ -216,6 +236,8 @@ class ImporterTest extends TestCase
     {
         $importer = $this->importerFactory->getImporter('xml');
 
-        $importer->import();
+        $importer
+            ->useImportConfiguration(new ChunkImportConfiguration())
+            ->import();
     }
 }


### PR DESCRIPTION
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `Importer::import` now throws exception if ImportConfiguration is not provided.

### Changed
- `KunicMarko\Importer\Import` has been renamed to `KunicMarko\Importer\ImportConfiguration`.
- `Importer::useImportClass` has been renamed to `Importer::useImportConfiguration`.
```
